### PR TITLE
adicionar github action para atualização automática (#4)

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to VPS
+
+on:
+  push:
+    branches:
+      - deploy
+    paths:
+      - client/*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Git checkout
+        uses: actions/checkout@v3
+      - name: Copy files
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USERNAME }}
+          password: ${{ secrets.VPS_PASSWORD }}
+          port: ${{ secrets.VPS_PORT }}
+          source: client/*
+          target: ${{ secrets.VPS_PATH }}
+          strip_components: 1
+
+  run:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USERNAME }}
+          password: ${{ secrets.VPS_PASSWORD }}
+          port: ${{ secrets.VPS_PORT }}
+          script: cd ${{ secrets.VPS_PATH }} && ls

--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -8,11 +8,13 @@ on:
       - client/*
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
+    
     steps:
       - name: Run Git checkout
         uses: actions/checkout@v3
+      
       - name: Copy files
         uses: appleboy/scp-action@v0.1.4
         with:
@@ -25,8 +27,9 @@ jobs:
           strip_components: 1
 
   run:
-    needs: deploy
+    needs: build
     runs-on: ubuntu-latest
+    
     steps:
       - name: Run
         uses: appleboy/ssh-action@v0.1.10
@@ -35,4 +38,6 @@ jobs:
           username: ${{ secrets.VPS_USERNAME }}
           password: ${{ secrets.VPS_PASSWORD }}
           port: ${{ secrets.VPS_PORT }}
-          script: cd ${{ secrets.VPS_PATH }} && ls
+          script: |
+            screen -XS stewartbot_gh quit
+            screen -dmS stewartbot_gh bash -c 'python ${{ secrets.VPS_PATH }}/stewart.py; exec sh'


### PR DESCRIPTION
A ação será acionada sempre que um commit no ramo ``deploy`` modificar _qualquer_ arquivo na pasta ``client``. Nesse caso, todos os arquivos em ``client`` serão movidos para uma pasta remota (``VPS_PATH``).

Eu tomei a liberdade de só copiar o conteúdo da pasta ``client``, mas se for necessário copiar todo o repositório, é só ajustar a linha 23 (``client/*`` -> ``.``), o bloco na linha 3 (``on: [...]``) e o comando na linha 42 (``python [...]/stewart.py``).

Para configurar, crie os segredos em [/settings/secrets/actions](https://github.com/GabrielRPrada/StewartBOT/settings/secrets/actions):
* ``VPS_HOST``: o IP
* ``VPS_PORT``: a porta
* ``VPS_USERNAME``: o usuário
* ``VPS_PASSWORD``: a senha¹
* ``VPS_PATH``: onde o conteúdo da pasta ``client`` será salvo (exemplo: ``/home/programas/StewartBOT``)

_¹ O ideal aqui é usar uma chave para a conexão, não se conectar através da senha. Aqui tem um tutorial de como fazer isso: [scp-command-to-transfer-files#setting-up-a-ssh-key](https://github.com/marketplace/actions/scp-command-to-transfer-files#setting-up-a-ssh-key)_